### PR TITLE
change the structure of ...

### DIFF
--- a/src/preferences.c
+++ b/src/preferences.c
@@ -30,6 +30,8 @@ void InitializePreferenceFile() {
   fputs(kSerializedJsonWithNewline, preferences);
   fclose(preferences);
   free(kSerializedJsonWithNewline);
+
+  cJSON_Delete(kJsonPreferences);
 }
 
 void SetUserPreference(const char* const key, const double value) {


### PR DESCRIPTION
InitializePreferenceFile and SetUserPreference So one function does not call the other, and fix possible memory leak.
I think this makes it more clear where the file is initialized if it does not already exists.